### PR TITLE
Refactor to close connections

### DIFF
--- a/get.go
+++ b/get.go
@@ -6,11 +6,20 @@ import (
 	"github.com/mjibson/snmp/mib"
 )
 
-// Get retrieves an object by its name.  Nameval is a pair of: object
-// name (string), and the corresponding target value (pointer to int,
-// string, etc.). To retrieve multiple objects in a single transaction,
-// provide multiple name, value pairs.
+// Get is a wrapper for SNMP.Get.
 func Get(host, community string, nameval ...interface{}) error {
+	s, err := New(host, community)
+	if err != nil {
+		return err
+	}
+	return s.Get(nameval...)
+}
+
+// Get retrieves an object by its name. Nameval is a pair of: object name or OID
+// (string), and the corresponding target value (pointer to int, string, etc.).
+// To retrieve multiple objects in a single transaction, provide multiple name,
+// value pairs.
+func (s *SNMP) Get(nameval ...interface{}) error {
 	switch n := len(nameval); {
 	case n == 0:
 		return nil
@@ -21,16 +30,12 @@ func Get(host, community string, nameval ...interface{}) error {
 	if err != nil {
 		return err
 	}
-	tr, err := newTransport(host, community)
-	if err != nil {
-		return err
-	}
-	req := &Request{
+	req := &request{
 		Type:     "Get",
 		Bindings: bindings,
 		ID:       <-nextID,
 	}
-	resp, err := tr.RoundTrip(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return err
 	}
@@ -39,8 +44,7 @@ func Get(host, community string, nameval ...interface{}) error {
 	}
 	for i, b := range resp.Bindings {
 		if have, want := b.Name, req.Bindings[i].Name; !have.Equal(want) {
-			return fmt.Errorf("snmp: %s: get %v: invalid response: name mismatch",
-				host, want)
+			return fmt.Errorf("snmp: get %v: invalid response: name mismatch", want)
 		}
 		v := nameval[2*i+1]
 		if err := b.unmarshal(v); err != nil {
@@ -51,8 +55,8 @@ func Get(host, community string, nameval ...interface{}) error {
 }
 
 // fromPairs creates bindings from the (name, value) pairs.
-func fromPairs(nameval []interface{}) ([]Binding, error) {
-	var bindings []Binding
+func fromPairs(nameval []interface{}) ([]binding, error) {
+	var bindings []binding
 	for i := 0; i < len(nameval); i += 2 {
 		s, ok := nameval[i].(string)
 		if !ok {
@@ -62,7 +66,7 @@ func fromPairs(nameval []interface{}) ([]Binding, error) {
 		if err != nil {
 			return nil, err
 		}
-		bindings = append(bindings, Binding{Name: oid})
+		bindings = append(bindings, binding{Name: oid})
 	}
 	return bindings, nil
 }

--- a/snmp.go
+++ b/snmp.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-// Reserved binding values.
+// reserved binding values.
 var (
 	null           = asn1.RawValue{Class: 0, Tag: 5}
 	noSuchObject   = asn1.RawValue{Class: 2, Tag: 0}
@@ -17,14 +17,14 @@ var (
 	endOfMibView   = asn1.RawValue{Class: 2, Tag: 2}
 )
 
-// Binding represents an assignment to a variable, a.k.a. managed object.
-type Binding struct {
+// binding represents an assignment to a variable, a.k.a. managed object.
+type binding struct {
 	Name  asn1.ObjectIdentifier
 	Value asn1.RawValue
 }
 
 // unmarshal stores in v the value part of binding b.
-func (b *Binding) unmarshal(v interface{}) error {
+func (b *binding) unmarshal(v interface{}) error {
 	convertClass(&b.Value)
 	_, err := asn1.Unmarshal(b.Value.FullBytes, v)
 	if err != nil {
@@ -80,7 +80,7 @@ func convertType(v interface{}) interface{} {
 }
 
 // less checks if a precedes b in the MIB tree.
-func (a Binding) less(b Binding) bool {
+func (a binding) less(b binding) bool {
 	switch {
 	case len(a.Name) < len(b.Name):
 		for i := 0; i < len(a.Name); i++ {
@@ -126,39 +126,33 @@ func (a Binding) less(b Binding) bool {
 	panic("unreached")
 }
 
-// A Request represents an SNMP request to be sent over a Transport.
-type Request struct {
+// request represents an SNMP request to be sent over a Transport.
+type request struct {
 	ID             int32
 	Type           string // "Get", "GetNext", "GetBulk"
-	Bindings       []Binding
+	Bindings       []binding
 	NonRepeaters   int
 	MaxRepetitions int
 }
 
-// Response represents the response from an SNMP request.
-type Response struct {
+// response represents the response from an SNMP request.
+type response struct {
 	ID          int32
 	ErrorStatus int
 	ErrorIndex  int
-	Bindings    []Binding
+	Bindings    []binding
 }
 
-// RoundTripper is an interface representing the ability to execute a
-// single SNMP transaction, obtaining the Response for a given Request.
-//
-// A RoundTripper must be safe for concurrent use by multiple goroutines.
-type RoundTripper interface {
-	RoundTrip(*Request) (*Response, error)
-}
-
-// Transport is an implementation of RoundTripper that supports SNMPv2
-// as defined by RFC 3416.
-type Transport struct {
-	Conn      net.Conn
+// SNMP performs SNMPv2 requests as defined by RFC 3416.
+type SNMP struct {
+	// Community is the SNMP community.
 	Community string
+	// Addr is the UDP address of the SNMP host.
+	Addr      *net.UDPAddr
 }
 
-func newTransport(host, community string) (*Transport, error) {
+// New creates a new SNMP which connects to host with specified community.
+func New(host, community string) (*SNMP, error) {
 	hostport := host
 	if _, _, err := net.SplitHostPort(hostport); err != nil {
 		hostport = host + ":161"
@@ -167,15 +161,13 @@ func newTransport(host, community string) (*Transport, error) {
 	if err != nil {
 		return nil, err
 	}
-	conn, err := net.DialUDP("udp", nil, addr)
-	if err != nil {
-		return nil, err
-	}
-	return &Transport{conn, community}, nil
+	return &SNMP{
+		Community: community,
+		Addr:      addr,
+	}, nil
 }
 
-// RoundTrip implements the RoundTripper interface.
-func (tr *Transport) RoundTrip(req *Request) (*Response, error) {
+func (s *SNMP) do(req *request) (*response, error) {
 	for i := range req.Bindings {
 		req.Bindings[i].Value = null
 	}
@@ -190,11 +182,11 @@ func (tr *Transport) RoundTrip(req *Request) (*Response, error) {
 				RequestID   int32
 				ErrorStatus int
 				ErrorIndex  int
-				Bindings    []Binding
+				Bindings    []binding
 			} `asn1:"application,tag:0"`
 		}
 		p.Version = 1
-		p.Community = []byte(tr.Community)
+		p.Community = []byte(s.Community)
 		p.Data.RequestID = req.ID
 		p.Data.Bindings = req.Bindings
 		buf, err = asn1.Marshal(p)
@@ -206,11 +198,11 @@ func (tr *Transport) RoundTrip(req *Request) (*Response, error) {
 				RequestID   int32
 				ErrorStatus int
 				ErrorIndex  int
-				Bindings    []Binding
+				Bindings    []binding
 			} `asn1:"application,tag:1"`
 		}
 		p.Version = 1
-		p.Community = []byte(tr.Community)
+		p.Community = []byte(s.Community)
 		p.Data.RequestID = req.ID
 		p.Data.Bindings = req.Bindings
 		buf, err = asn1.Marshal(p)
@@ -222,11 +214,11 @@ func (tr *Transport) RoundTrip(req *Request) (*Response, error) {
 				RequestID      int32
 				NonRepeaters   int
 				MaxRepetitions int
-				Bindings       []Binding
+				Bindings       []binding
 			} `asn1:"application,tag:5"`
 		}
 		p.Version = 1
-		p.Community = []byte(tr.Community)
+		p.Community = []byte(s.Community)
 		p.Data.RequestID = req.ID
 		p.Data.NonRepeaters = 0
 		p.Data.MaxRepetitions = req.MaxRepetitions
@@ -238,14 +230,19 @@ func (tr *Transport) RoundTrip(req *Request) (*Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	if _, err := tr.Conn.Write(buf); err != nil {
+	conn, err := net.DialUDP("udp", nil, s.Addr)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	if _, err := conn.Write(buf); err != nil {
 		return nil, err
 	}
 	buf = make([]byte, 10000, 10000)
-	if err := tr.Conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
 		return nil, err
 	}
-	n, err := tr.Conn.Read(buf)
+	n, err := conn.Read(buf)
 	if err != nil {
 		return nil, err
 	}
@@ -259,19 +256,19 @@ func (tr *Transport) RoundTrip(req *Request) (*Response, error) {
 			RequestID   int32
 			ErrorStatus int
 			ErrorIndex  int
-			Bindings    []Binding
+			Bindings    []binding
 		} `asn1:"tag:2"`
 	}
 	if _, err = asn1.Unmarshal(buf[:n], &p); err != nil {
 		return nil, err
 	}
-	resp := &Response{p.Data.RequestID, p.Data.ErrorStatus, p.Data.ErrorIndex, p.Data.Bindings}
+	resp := &response{p.Data.RequestID, p.Data.ErrorStatus, p.Data.ErrorIndex, p.Data.Bindings}
 	return resp, nil
 }
 
 // check checks the response PDU for basic correctness.
 // Valid with all PDU types.
-func check(resp *Response, req *Request) (err error) {
+func check(resp *response, req *request) (err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("invalid response: %v", err)

--- a/walk.go
+++ b/walk.go
@@ -8,6 +8,15 @@ import (
 	"github.com/mjibson/snmp/mib"
 )
 
+// Walk is a wrapper for SNMP.Walk.
+func Walk(host, community string, oids ...string) (*Rows, error) {
+	s, err := New(host, community)
+	if err != nil {
+		return nil, err
+	}
+	return s.Walk(oids...)
+}
+
 // Rows is the result of a walk. Its cursor starts before the first
 // row of the result set. Use Next to advance through the rows:
 //
@@ -21,39 +30,33 @@ import (
 //     err = rows.Err() // get any error encountered during iteration
 //     ...
 type Rows struct {
-	avail     []row
-	last      row
-	walkFn    walkFunc
-	headText  []string
-	head      []asn1.ObjectIdentifier
-	Transport RoundTripper
-	host      string
-	err       error
+	avail    []row
+	last     row
+	walkFn   walkFunc
+	headText []string
+	head     []asn1.ObjectIdentifier
+	err      error
+	request  requestFunc
 }
 
 // row represents individual row.
 type row struct {
 	instance []int
-	bindings []Binding
+	bindings []binding
 }
 
 // Walk executes a query against host authenticated by the community string,
 // retrieving the MIB sub-tree defined by the the given root oids.
-func Walk(host, community string, oids ...string) (*Rows, error) {
-	tr, err := newTransport(host, community)
-	if err != nil {
-		return nil, err
-	}
+func (s *SNMP) Walk(oids ...string) (*Rows, error) {
 	rows := &Rows{
-		avail:     nil,
-		walkFn:    walkN,
-		headText:  oids,
-		head:      lookup(oids...),
-		Transport: tr,
-		host:      host,
+		avail:    nil,
+		walkFn:   walkN,
+		headText: oids,
+		head:     lookup(oids...),
+		request:  s.do,
 	}
 	for _, oid := range rows.head {
-		rows.last.bindings = append(rows.last.bindings, Binding{Name: oid})
+		rows.last.bindings = append(rows.last.bindings, binding{Name: oid})
 	}
 	return rows, nil
 }
@@ -74,12 +77,12 @@ func (rows *Rows) Next() bool {
 		return false
 	}
 
-	row, err := rows.walkFn(rows.last.bindings, rows.Transport)
+	row, err := rows.walkFn(rows.last.bindings, rows.request)
 	if err != nil {
 		if err == io.EOF {
 			rows.err = err
 		} else {
-			rows.err = fmt.Errorf("snmp.Walk: %s: %v", rows.host, err)
+			rows.err = fmt.Errorf("snmp.Walk: %v", err)
 		}
 		return false
 	}
@@ -173,17 +176,19 @@ func (rows *Rows) Err() error {
 	return rows.err
 }
 
+type requestFunc func(*request) (*response, error)
+
 // walkFunc is a function that can request one or more rows.
-type walkFunc func([]Binding, RoundTripper) ([]row, error)
+type walkFunc func([]binding, requestFunc) ([]row, error)
 
 // walk1 requests one row.
-func walk1(have []Binding, tr RoundTripper) ([]row, error) {
-	req := &Request{
+func walk1(have []binding, rf requestFunc) ([]row, error) {
+	req := &request{
 		Type:     "GetNext",
 		ID:       <-nextID,
 		Bindings: have,
 	}
-	resp, err := tr.RoundTrip(req)
+	resp, err := rf(req)
 	if err != nil {
 		return nil, err
 	}
@@ -195,15 +200,15 @@ func walk1(have []Binding, tr RoundTripper) ([]row, error) {
 }
 
 // walkN requests a range of rows.
-func walkN(have []Binding, tr RoundTripper) ([]row, error) {
-	req := &Request{
+func walkN(have []binding, rf requestFunc) ([]row, error) {
+	req := &request{
 		Type:           "GetBulk",
 		ID:             <-nextID,
 		Bindings:       have,
 		NonRepeaters:   0,
 		MaxRepetitions: 15,
 	}
-	resp, err := tr.RoundTrip(req)
+	resp, err := rf(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The PR in #1 would have fixed this problem for Get requests, but only because of
how the SNMP package uses the connection structure. Walk requests, though, would
have used the closed connection on requests after the first and thus been
broken.

Instead, just make a new connection each time with the UDP dialer. It
appears that the structure of this package was copied from net/http, which
may not have been a good model. In any case, we can now have a better API
if one is doing multiple requests to the same host, while maintaining the
old API.

fixes #2
closes #1